### PR TITLE
Windowsfriendly2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ exports.convertToHtml = function(options) {
 	var outputDir = options["output-dir"];
 	var styleMapPath = options["style-map"];
 	var styleFunctionsPath = options["style-functions"];
-	var docxFileName = docxPath.substr(docxPath.lastIndexOf(path.sep) + 1);
+	var docxFileName = docxPath.substr(docxPath.lastIndexOf('/') + 1).substr(docxPath.lastIndexOf('\\') + 1);
 	var htmlFileName = path.join(outputDir, docxFileName.substring(0, docxFileName.lastIndexOf(".")) + ".html");
 	var mammothFileName = path.join(outputDir, "MAM" + docxFileName.substring(0, docxFileName.lastIndexOf(".")) + ".json");
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,9 +13,6 @@ function main(argv) {
 	var htmlFileName = path.join(outputDir, docxFileName.substring(0, docxFileName.lastIndexOf(".")) + ".html");
 	var mammothFileName = path.join(outputDir, "MAM" + docxFileName.substring(0, docxFileName.lastIndexOf(".")) + ".json");
 
-console.log("DOCXFN:" +docxFileName)
-console.log("htmlFileName:" +htmlFileName)
-
 	promises.nfcall(fs.readFile, styleMapPath, "utf8").then(function(stylesJson) {
 		var converter = new Convert(styleFunctionsPath);
 		// UNCOMMENT BELOW TO RETURN MAMMOTH JSON

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,9 +9,12 @@ function main(argv) {
 	var outputDir = argv["output-dir"];
 	var styleMapPath = argv["style-map"];
 	var styleFunctionsPath = argv["style-functions"];
-	var docxFileName = docxPath.substr(docxPath.lastIndexOf(path.sep) + 1);
+	var docxFileName = docxPath.substr(docxPath.lastIndexOf('/') + 1).substr(docxPath.lastIndexOf('\\') + 1);
 	var htmlFileName = path.join(outputDir, docxFileName.substring(0, docxFileName.lastIndexOf(".")) + ".html");
 	var mammothFileName = path.join(outputDir, "MAM" + docxFileName.substring(0, docxFileName.lastIndexOf(".")) + ".json");
+
+console.log("DOCXFN:" +docxFileName)
+console.log("htmlFileName:" +htmlFileName)
 
 	promises.nfcall(fs.readFile, styleMapPath, "utf8").then(function(stylesJson) {
 		var converter = new Convert(styleFunctionsPath);


### PR DESCRIPTION
@nelliemckesson ; so the previous PR allowed me to run htmlmaker from command line on the server; however when I ran the command via ruby it passed the parameters with '/', instead of the expected path.sep (default for the OS), '\'.  There's no alt_separator constant like in ruby, so I just explicitly planned for both path separators in the two .js files that needed it.
(tested on Windows & Mac)