### PR TITLE
changed Section-Contents class to texttoc

### DIFF
--- a/style_config.json
+++ b/style_config.json
@@ -223,7 +223,7 @@
     ".Section-Contentsstc": [
         {"type": "preface",
         "label": "Contents",
-        "class": "contents"}
+        "class": "texttoc"}
     ],
     ".Section-Forewordsfw": [
         {"type": "foreword"}


### PR DESCRIPTION
PR 3 of 3 - for handling of auto/manual TOC display with Section Start Styles. See:
macmillanpublishers/bookmaker#179

@nelliemckesson , please review?