### PR TITLE
Chapnumber

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -130,7 +130,7 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
 		}
 		if (para.type == "paragraph") {
 			if (index > 0) {
-				convert.convertDocxParagraph(para, styles, docxStyles, paras[index - 1]);
+				convert.convertDocxParagraph(para, styles, docxStyles, paras[index - 1], paras[index + 1]);
 			} else {
 				convert.convertDocxParagraph(para, styles, docxStyles);
 			}
@@ -197,12 +197,17 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
   $('section.endnotes:empty').remove();
 
   $('.FMHeadNonprintingfmhnp:last-child, .BMHeadNonprintingbmhnp:last-child, .ChapTitleNonprintingctnp:last-child, .ChapTitlect:last-child').remove();
+
+  // add comments for ChapNumbers converted to data-autolabels
+  var cnAutoLabel = $(".ChapTitlect[data-autolabel='yes'], .ChapTitleALTact[data-autolabel='yes']");
+  var comment = $('<!--A Chapter Number paragraph (.ChapNumbercn) directly preceding this Chapter Title paragraph was removed during conversion to html. Its content was added to the Chapter Title element as the value of "data-labeltext".-->');
+  cnAutoLabel.after(comment);
   // END POSTPROCESSING
 
 	return this.document.html();
 };
 
-Convert.prototype.convertDocxParagraph = function (para, styles, docxStyles, prevPara) {
+Convert.prototype.convertDocxParagraph = function (para, styles, docxStyles, prevPara, nextPara) {
 	var $ = this.document;
 	var convert = this;
 	var tags = styles.tagsForDocxStyle(para.styleId);
@@ -261,8 +266,10 @@ Convert.prototype.convertDocxParagraph = function (para, styles, docxStyles, pre
 			convert.behaviorFunctions[behavior["name"]](tag, tagStyle, behavior);
 			return;
 		}
-		// add exclusion not to create chapnumber paras if followed by chap title?
-		addHtmlToDoc(tag["tag-name"], behavior, tagStyle);
+		// add exclusion not to create chapnumber paras if followed by chap title
+    if (!(para.styleId == 'ChapNumbercn' && nextPara.styleId == 'ChapTitlect') && !(para.styleId == 'ChapNumbercn' && nextPara.styleId == 'ChapTitleALTact')) {
+		    addHtmlToDoc(tag["tag-name"], behavior, tagStyle);
+    }
 	}
 
 	// Create the html element and add it to the doc based on its style behavior
@@ -303,13 +310,10 @@ Convert.prototype.convertDocxParagraph = function (para, styles, docxStyles, pre
 		htmlEl.attr("id", id);
 
     // add chapter number content to chapter titles as attributes
-    if ()(para.styleId == 'ChapTitlect' && prevPara.styleId == 'ChapNumbercn') || (para.styleId == 'ChapTitleALTact' && prevPara.styleId == 'ChapNumbercn')) {
+    if ((para.styleId == 'ChapTitlect' && prevPara.styleId == 'ChapNumbercn') || (para.styleId == 'ChapTitleALTact' && prevPara.styleId == 'ChapNumbercn')) {
 			htmlEl.attr("data-autolabel", "yes");
 			var labeltext = convert.aggregateParaText(prevPara);
 			htmlEl.attr("data-labeltext", labeltext);
-      var comment = document.createComment("A Chapter Number paragraph (.ChapNumbercn) directly preceded this Chapter Title paragraph; it was removed and its content added to the ChapTitle as 'data-labeltext' value.");
-      para.after(comment)
-      // prevPara.remove()
 		};
 
 		if (para.numbering) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -266,9 +266,9 @@ Convert.prototype.convertDocxParagraph = function (para, styles, docxStyles, pre
 			convert.behaviorFunctions[behavior["name"]](tag, tagStyle, behavior);
 			return;
 		}
-		// add exclusion not to create chapnumber paras if followed by chap title
+		// don't create chapnumber paras if followed by ChapTitlect or ChapTitleALTCT
     if (!(para.styleId == 'ChapNumbercn' && nextPara.styleId == 'ChapTitlect') && !(para.styleId == 'ChapNumbercn' && nextPara.styleId == 'ChapTitleALTact')) {
-		    addHtmlToDoc(tag["tag-name"], behavior, tagStyle);
+      addHtmlToDoc(tag["tag-name"], behavior, tagStyle);
     }
 	}
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -303,10 +303,13 @@ Convert.prototype.convertDocxParagraph = function (para, styles, docxStyles, pre
 		htmlEl.attr("id", id);
 
     // add chapter number content to chapter titles as attributes
-    if (para.styleId == 'ChapTitlect' && prevPara.styleId == 'ChapNumbercn') {
+    if ()(para.styleId == 'ChapTitlect' && prevPara.styleId == 'ChapNumbercn') || (para.styleId == 'ChapTitleALTact' && prevPara.styleId == 'ChapNumbercn')) {
 			htmlEl.attr("data-autolabel", "yes");
 			var labeltext = convert.aggregateParaText(prevPara);
 			htmlEl.attr("data-labeltext", labeltext);
+      var comment = document.createComment("A Chapter Number paragraph (.ChapNumbercn) directly preceded this Chapter Title paragraph; it was removed and its content added to the ChapTitle as 'data-labeltext' value.");
+      para.after(comment)
+      // prevPara.remove()
 		};
 
 		if (para.numbering) {
@@ -314,7 +317,7 @@ Convert.prototype.convertDocxParagraph = function (para, styles, docxStyles, pre
 			if (para.styleId != prevPara.styleId) {
 				htmlEl.addClass("liststart");
 			};
-		}; 
+		};
 
     // OLD nav handling to insert nav before a user-defined element.
     // This has been changed so nav is inserted following header, always.


### PR DESCRIPTION
@nelliemckesson, please review
This does the 3 things we talked about:
- adds support for class .ChapTitleALTact as a Chapter Title para when converting ChapNumbers to data-autolabels
- removes the Chapter Number para
- adds a comment after the Chapter Title.

I tried to stay within the flow of convert.js, let me know if you want me to do this a different way!