### PR TITLE
Converting direct formatting to semantic tags

### DIFF
--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -107,6 +107,16 @@ function moveLeadingVersatileParas(myParentSelector) {
     });
   }
 
+//function to replace element, keeping innerHtml BUt NOT attributes
+  function replaceElNoAttr(selector, newTag) {
+    selector.each(function(){
+      var myHtml = $(this).html();
+      $(this).replaceWith(function(){
+          return $(newTag).html(myHtml);
+      });
+    });
+  }
+
 // a function to make an id
   function makeID() {
     idCounter++;
@@ -574,6 +584,21 @@ chapTitlePara.each(function() {
   chapNumberPara.remove();
   $(this).after(comment);
 });
+
+// Fixing markup of spans styled with direct formatting
+$("span[style='font-weight: bold; font-style: italic;']").each(function( ){
+  var myHtml = $(this).html();
+  $(this).wrap("<strong/>");
+  $(this).replaceWith(function(){
+      return $("<em/>").html(myHtml);
+  });
+});
+
+var ems = $("span[style='font-style: italic;']");
+var strongs = $("span[style='font-weight: bold;']");
+
+replaceElNoAttr (ems, "<em/>");
+replaceElNoAttr (strongs, "<strong/>");
 
 // removing unneccessary paras.
 // THIS NEEDS TO HAPPEN LAST


### PR DESCRIPTION
Find direct italic and bold formatting and converts it to semantic em and strong tags. 

Fixes #40