### PR TITLE
adding patch to make sure text that may have been nested in w:br elem…

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -68,6 +68,7 @@ var Convert = function (styleFunctionsPath) {
 			} else if (isLineBreak == true) {
 				var br = $("<br/>");
 				text.push(br);
+				text.push(paraText);
 			} else {
 				text.push(paraText);
 			}


### PR DESCRIPTION
…ent in xsl is not omitted.

@nelliemckesson, please review?
This fixes : https://github.com/macmillanpublishers/htmlmaker_js/issues/58