### PR TITLE
Endnoteshead

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -149,8 +149,7 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
   var notesjson = docx.value.notes._notes;
   var notesjsonarr = Object.keys(notesjson).map(function(k) { return notesjson[k] });
   var footnotesection = $("<section data-type='appendix' class='footnotes'></section>");
-  var endnotesection = $("<section data-type='appendix' class='endnotes'></section>");
-  // run through each note, convert it to paras, and append to notes section
+  // find each footnote in notes, convert it to paras, and append to notes section
   notesjsonarr.forEach(function (note, index, paras) {
   	if (note.noteType == "footnote") {
   		  var noteparent = $("<div class='footnote'></div>");
@@ -164,7 +163,12 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
 					noteparent.append(p);
 				});
 				footnotesection.append(noteparent);
-		} else if (note.noteType == "endnote") {
+		}
+		convert.body.append(footnotesection);
+  });
+  // find each endnote in notes, convert it to paras, and append to body
+  notesjsonarr.forEach(function (note, index, paras) {
+    if (note.noteType == "endnote") {
   		  var noteparent = $("<div class='endnotetext'></div>");
   		  var endnoteid = "endnotetext-" + note.noteId;
   		  noteparent.attr("id", endnoteid);
@@ -176,12 +180,10 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
 					p.append(convert.aggregateParaText(para));
 					noteparent.append(p);
 				});
-				endnotesection.append(noteparent);
-		} else {
+				convert.body.append(noteparent);
+		} else if (note.noteType != "footnote") {
 			console.log(note.type);
 		};
-		convert.body.append(footnotesection);
-		convert.body.append(endnotesection);
   });
 
   // INSERT ANY DOC POSTPROCESSING INSTRUX HERE

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -149,7 +149,7 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
   var notesjson = docx.value.notes._notes;
   var notesjsonarr = Object.keys(notesjson).map(function(k) { return notesjson[k] });
   var footnotesection = $("<section data-type='appendix' class='footnotes'></section>");
-  // find each footnote in notes, convert it to paras, and append to notes section
+  // find each footnote in notes, convert them to paras, and append to notes section
   notesjsonarr.forEach(function (note, index, paras) {
   	if (note.noteType == "footnote") {
   		  var noteparent = $("<div class='footnote'></div>");
@@ -164,9 +164,10 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
 				});
 				footnotesection.append(noteparent);
 		}
+    // append notes section to body
 		convert.body.append(footnotesection);
   });
-  // find each endnote in notes, convert it to paras, and append to body
+  // find each endnote in notes, convert them to paras, and append directly to body
   notesjsonarr.forEach(function (note, index, paras) {
     if (note.noteType == "endnote") {
   		  var noteparent = $("<div class='endnotetext'></div>");

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -157,13 +157,13 @@ var toplevelheadslist = alltoplevelsections.join(", ");
 // loop through each divider paragraph and
 // create a parent section around it
 for (var k in toplevelheads) {
-  var newType = toplevelheads[k][0].type;
-  var newClass = toplevelheads[k][0].class;
-  var newLabel = toplevelheads[k][0].label;
+  var newType = toplevelheads[k].type;
+  var newClass = toplevelheads[k].class;
+  var newLabel = toplevelheads[k].label;
   $( k ).each(function() {
     var nextsiblings = $(this).nextUntil(toplevelheadslist).addBack();
     var newTag = "<section/>";
-    if (toplevelheads[k][0].type == "part") {
+    if (toplevelheads[k].type == "part") {
       newTag = "<div/>"
     };
     var myID = makeID();
@@ -491,8 +491,8 @@ var endnotelist = endnotetextselector.join(", ");
 var endnotelistselector = $(endnotelist);
 
 var endnoteconfig = toplevelheads['.Section-Notessnt'];
-var endnoteparent = $("<section data-type=" + endnoteconfig[0]['type'] + " class=" + endnoteconfig[0]['class'] + ">");
-var endnoteheading =$("<h1>" + endnoteconfig[0]['label'] + "</h1>");
+var endnoteparent = $("<section data-type=" + endnoteconfig['type'] + " class=" + endnoteconfig['class'] + ">");
+var endnoteheading =$("<h1>" + endnoteconfig['label'] + "</h1>");
 endnoteparent.append(endnoteheading);
 
 endnotelistselector.each(function() {

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -164,7 +164,7 @@ for (var k in toplevelheads) {
     var nextsiblings = $(this).nextUntil(toplevelheadslist).addBack();
     var newTag = "<section/>";
     if (toplevelheads[k].type == "part") {
-      newTag = "<div/>"
+      newTag = "<div/>";
     };
     var myID = makeID();
     var newsection = $(newTag).attr("data-type", newType).attr("id", myID).addClass("temp");
@@ -486,7 +486,7 @@ $("span[data-type='footnote'] p").each(function(){
 
 $('section.footnotes:empty').remove();
 
-// Create Endnotes section & heading, move endnote text into the section
+// Create endnotes section & heading, move endnote text into new endnotes section
 var endnotelist = endnotetextselector.join(", ");
 var endnotelistselector = $(endnotelist);
 
@@ -496,10 +496,10 @@ var endnoteheading =$("<h1>" + endnoteconfig['label'] + "</h1>");
 endnoteparent.append(endnoteheading);
 
 endnotelistselector.each(function() {
-  endnoteparent.append(this)
+  endnoteparent.append(this);
 });
 
-$('body').append(endnoteparent)
+$('body').append(endnoteparent);
 
 // create heading tags
 var headingslist = headingparas.join(", ");

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -52,6 +52,7 @@ var orderedlistparas = jsonParsed['orderedlistparas'];
 var unorderedsublistparas = jsonParsed['unorderedsublistparas'];
 var orderedsublistparas = jsonParsed['orderedsublistparas'];
 var footnotetextselector = jsonParsed['footnotetextselector'];
+var endnotetextselector = jsonParsed['endnotetextselector'];
 var omitparas = jsonParsed['omitparas'];
 var versatileblockparas = jsonParsed['versatileblockparas'];
 
@@ -484,6 +485,21 @@ $("span[data-type='footnote'] p").each(function(){
 });
 
 $('section.footnotes:empty').remove();
+
+// Create Endnotes section & heading, move endnote text into the section
+var endnotelist = endnotetextselector.join(", ");
+var endnotelistselector = $(endnotelist);
+
+var endnoteconfig = toplevelheads['.Section-Notessnt'];
+var endnoteparent = $("<section data-type=" + endnoteconfig[0]['type'] + " class=" + endnoteconfig[0]['class'] + ">");
+var endnoteheading =$("<h1>" + endnoteconfig[0]['label'] + "</h1>");
+endnoteparent.append(endnoteheading);
+
+endnotelistselector.each(function() {
+  endnoteparent.append(this)
+});
+
+$('body').append(endnoteparent)
 
 // create heading tags
 var headingslist = headingparas.join(", ");

--- a/style_config.json
+++ b/style_config.json
@@ -298,5 +298,8 @@
   },
   "footnotetextselector": [
     "div.footnote"
+  ],
+  "endnotetextselector": [
+    "div.endnotetext"
   ]
 }

--- a/style_config.json
+++ b/style_config.json
@@ -223,7 +223,7 @@
     ".Section-Contentsstc": {
       "type": "preface",
       "label": "Contents",
-      "class": "contents"
+      "class": "texttoc"
     },
     ".Section-Forewordsfw": {
       "type": "foreword"

--- a/style_config.json
+++ b/style_config.json
@@ -184,117 +184,117 @@
     ".SpaceBreak-Internalint"
   ],
   "toplevelheads": {
-    ".Section-Front-Salessfs": [
-        {"type": "preface",
-        "label": "Front Sales",
-        "class": "frontsales"}
-    ],
-    ".Section-Halftitlesht": [
-        {"type": "halftitlepage",
-        "label": "Half Title Page"}
-    ],
-    ".Section-Series-Pagessp": [
-        {"type": "preface",
-        "label": "Series Page",
-        "class": "seriespage"}
-    ],
-    ".Section-Ad-Cardsac": [
-        {"type": "preface",
-        "label": "Ad Card",
-        "class": "adcard"}
-    ],
-    ".Section-Titlepagesti": [
-        {"type": "titlepage",
-        "label": "Title Page"}
-    ],
-    ".Section-Copyrightscr": [
-        {"type": "copyright-page",
-        "label": "Copyright Page"}
-    ],
-    ".Section-Dedicationsde": [
-        {"type": "dedication",
-        "label": "Dedication"}
-    ],
-    ".Section-Epigraphsepi": [
-        {"type": "preface",
-        "label": "Epigraph",
-        "class": "epigraph"}
-    ],
-    ".Section-Contentsstc": [
-        {"type": "preface",
-        "label": "Contents",
-        "class": "texttoc"}
-    ],
-    ".Section-Forewordsfw": [
-        {"type": "foreword"}
-    ],
-    ".Section-Prefacespf": [
-        {"type": "preface"}
-    ],
-    ".Section-Blank-Pagesbl": [
-        {"type": "preface",
-        "class": "blankpage"}
-    ],
-    ".Section-Intro-Frontmattersif": [
-        {"type": "introduction"}
-    ],
-    ".Section-Intro-Chaptersic": [
-        {"type": "chapter",
-        "label": "Introduction"}
-    ],
-    ".Section-Partspt": [
-        {"type": "part"}
-    ],
-    ".Section-Chapterscp": [
-        {"type": "chapter"}
-    ],
-    ".Section-Conclusionscl": [
-        {"type": "conclusion",
-        "label": "Conclusion"}
-    ],
-    ".Section-Appendixsap": [
-        {"type": "appendix"}
-    ],
-    ".Section-Afterwordsaw": [
-        {"type": "afterword"}
-    ],
-    ".Section-Acknowledgmentssak": [
-        {"type": "acknowledgments"}
-    ],
-    ".Section-Glossarysgl": [
-        {"type": "glossary"}
-    ],
-    ".Section-Notessnt": [
-        {"type": "appendix",
-        "label": "Notes",
-        "class": "notes"}
-    ],
-    ".Section-Bibliographysbi": [
-        {"type": "bibliography"}
-    ],
-    ".Section-Excerpt-Openerseo": [
-        {"type": "appendix",
-        "label": "Excerpt Introduction",
-        "class": "excerptopener"}
-    ],
-    ".Section-Excerpt-Chaptersec": [
-        {"type": "appendix",
-        "label": "Excerpt",
-        "class": "excerptchapter"}
-    ],
-    ".Section-About-Authorsaa": [
-        {"type": "appendix",
-        "label": "About the Author",
-        "class": "abouttheauthor"}
-    ],
-    ".Section-Back-Adsba": [
-        {"type": "appendix",
-        "label": "Ad",
-        "class": "backad"}
-    ],
-    ".Section-Indexsin": [
-        {"type": "index"}
-    ]
+    ".Section-Front-Salessfs": {
+      "type": "preface",
+      "label": "Front Sales",
+      "class": "frontsales"
+    },
+    ".Section-Halftitlesht": {
+      "type": "halftitlepage",
+      "label": "Half Title Page"
+    },
+    ".Section-Ad-Cardsac": {
+      "type": "preface",
+      "label": "Ad Card",
+      "class": "adcard"
+    },
+    ".Section-Series-Pagessp": {
+      "type": "preface",
+      "label": "Series Page",
+      "class": "seriespage"
+    },
+    ".Section-Titlepagesti": {
+      "type": "titlepage",
+      "label": "Title Page"
+    },
+    ".Section-Copyrightscr": {
+      "type": "copyright-page",
+      "label": "Copyright Page"
+    },
+    ".Section-Dedicationsde": {
+      "type": "dedication",
+      "label": "Dedication"
+    },
+    ".Section-Epigraphsepi": {
+      "type": "preface",
+      "label": "Epigraph",
+      "class": "epigraph"
+    },
+    ".Section-Contentsstc": {
+      "type": "preface",
+      "label": "Contents",
+      "class": "contents"
+    },
+    ".Section-Forewordsfw": {
+      "type": "foreword"
+    },
+    ".Section-Prefacespf": {
+      "type": "preface"
+    },
+    ".Section-Intro-Frontmattersif": {
+      "type": "introduction"
+    },
+    ".Section-Intro-Chaptersic": {
+      "type": "chapter",
+      "label": "Introduction"
+    },
+    ".Section-Partspt": {
+      "type": "part"
+    },
+    ".Section-Chapterscp": {
+      "type": "chapter"
+    },
+    ".Section-Conclusionscl": {
+      "type": "conclusion",
+      "label": "Conclusion"
+    },
+    ".Section-Afterwordsaw": {
+      "type": "afterword"
+    },
+    ".Section-Acknowledgmentssak": {
+      "type": "acknowledgments"
+    },
+    ".Section-Appendixsap": {
+      "type": "appendix"
+    },
+    ".Section-Glossarysgl": {
+      "type": "glossary"
+    },
+    ".Section-Excerpt-Chaptersec": {
+      "type": "appendix",
+      "label": "Excerpt",
+      "class": "excerptchapter"
+    },
+    ".Section-Excerpt-Openerseo": {
+      "type": "appendix",
+      "label": "Excerpt Introduction",
+      "class": "excerptopener"
+    },
+    ".Section-Bibliographysbi": {
+      "type": "bibliography"
+    },
+    ".Section-Notessnt": {
+      "type": "appendix",
+      "label": "Notes",
+      "class": "notes"
+    },
+    ".Section-About-Authorsaa": {
+      "type": "appendix",
+      "label": "About the Author",
+      "class": "abouttheauthor"
+    },
+    ".Section-Back-Adsba": {
+      "type": "appendix",
+      "label": "Ad",
+      "class": "bobad"
+    },
+    ".Section-Indexsin": {
+      "type": "index"
+    },
+    ".Section-Blank-Pagesbl": {
+      "type": "preface",
+      "class": "blankpage"
+    }
   },
   "footnotetextselector": [
     "div.footnote"


### PR DESCRIPTION
@nelliemckesson , this is ready for review!

This is to fix: https://github.com/macmillanpublishers/htmlmaker_js/issues/54, as well as updating style-config.json as per https://github.com/macmillanpublishers/Word-template_assets/pull/27

Here's an overview of what's going on here:

convert.js:  
I removed the endnote section from convert.js, so endnote text is being appended directly to body. I separated the 'notes' loop into separate loops for footnotes and endnotes, so endnotes would be appended to the body after the footnotes div.

style_config.json:
• I updated the json structure for toplevelheads; sub-items were nested in an extraneous array.
• I changed the class of Section-BackAd to bobad, to match [sections.json](https://github.com/macmillanpublishers/bookmaker_assets/blob/master/sections.json), to fix  https://github.com/macmillanpublishers/htmlmaker_js/issues/39

htmltohtmlbook.js:  
• I added an endnote parent element and header, and consolidated endnotetext under that.  
• I updated references to match the new toplevelheads structure (from the updated style-config.json).  To test I diffed the output of htmltohtmlbook.js, with console logging to make sure all the same type class and label values were gotten (I diffed the console log output too:)
