### PR TITLE
Using sectionstart para contents for epub ncx/toc (including "notoc" instruction)

### DIFF
--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -508,11 +508,13 @@ var endnoteparent = $("<section data-type=" + endnoteconfig['type'] + " class=" 
 var endnoteheading =$("<h1>" + endnoteconfig['label'] + "</h1>");
 endnoteparent.append(endnoteheading);
 
-endnotelistselector.each(function() {
-  endnoteparent.append(this);
-});
-
-$('body').append(endnoteparent);
+// if we have any endnotes, add our new section with endnotes appended
+if (endnotelistselector.length > 0) {
+  endnotelistselector.each(function() {
+    endnoteparent.append(this);
+  });
+  $('body').append(endnoteparent);
+}
 
 // create heading tags
 var headingslist = headingparas.join(", ");

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -176,17 +176,23 @@ for (var k in toplevelheads) {
     if (newLabel !== undefined) {
       newsection.attr("title", newLabel);
     };
+    if ($(this).text() == "notoc") {
+      newsection.addClass("notoc");
+      $(this).text("")
+    }
     $(this).before(newsection);
     var node = $(".temp");
     node.append(nextsiblings);
     $(".temp").removeClass("temp");
+    // add a class to the old divider paras so we can grab them later & use contents for section headers
+    $(this).addClass("sectionstartpara")
   });
 };
 
-// remove the old divider paragraphs
-toplevelheadsarr.forEach(function ( val ) {
-  $( val ).remove();
-});
+// // remove the old divider paragraphs
+// toplevelheadsarr.forEach(function ( val ) {
+//   $( val ).remove();
+// });
 
 // wrap extracts in blockquote; include versatile paragraphs
 var extractAndVersatileParas = extractparas.concat(versatileblockparas);
@@ -522,6 +528,9 @@ headingslistselector.each(function(){
 
 // SETTING THE HEADER:
 
+// All of the below lines for setting the Header will be used as a fallback for the new primary method; which is capturing the Section Start Para contents
+// $("section, div[data-type='part']").each(function( ){
+
 // functions for counting sections, so we can autonumber if needed
 function getAutoNumber(mySelector) {
   var n = $(mySelector).length;
@@ -540,57 +549,74 @@ function getCounter(myHash, mySelector) {
 var hash = {};
 
 // creating the header block;
-// this relies on the h1 tags that are created previously
+// primarily we want content entered by the user, we may use previous setup as a backup.. commenting for now
+// (that relied on that we h1 tags created previously)
 $("section, div[data-type='part']").each(function( ){
-  var myHeading = $(this).children("h1").first().clone().removeAttr("class").removeAttr("id");
-  var myTitle = $(this).attr("title");
-  var myType = $(this).attr("data-type");
-  var myEl = this.tagName.toLowerCase();
+  var sectionStartParaContent = $(this).children("p.sectionstartpara").first().text();
+  if (sectionStartParaContent != "") {
+    console.log("found " + sectionStartParaContent); // debug
+    // Now we're not inserting a header if there's no section start para contents?
+    // Cuz if we insert a blank, well, should we insert a blank? if so just uncomment this block below, adn
+    // remove bracket from the end below... well what happens to th eTOC? We should test both ways.
+    // maybe the empty string is fine too
+  // } else {
+  //   sectionStartParaContent = " " // so we have something in there... but this may interfere with
+  // }
+  // old header handling:
+  // var myHeading = $(this).children("h1").first().clone().removeAttr("class").removeAttr("id");
+  // var myTitle = $(this).attr("title");
+  // var myType = $(this).attr("data-type");
+  // var myEl = this.tagName.toLowerCase();
+  //
+  // // get the total number of elements of this type
+  // var mySelector = "";
+  // var totalEls = "";
+  // var myLabel = "";
+  // var myCounter = "";
+  //
+  // // if there is no h1 element found BUT there is a title attribute on the section,
+  // // use the title attribute as the heading text
+  // if (myHeading[0] === undefined && myTitle !== undefined) {
+  //   mySelector = myEl + "[title='" + myTitle + "']";
+  //   totalEls = getAutoNumber(mySelector);
+  //   myCounter = getCounter(hash, myTitle);
+  //   myLabel = myTitle;
+  // // otherwise if there is no h1 element, use the data-type value
+  // } else if (myHeading[0] === undefined && myTitle === undefined) {
+  //   // adjust the capitalization of the data-type value for human-readability
+  //   mySelector = myEl + "[data-type='" + myType + "']";
+  //   totalEls = getAutoNumber(mySelector);
+  //   myCounter = getCounter(hash, myType);
+  //   myLabel = myType.toLowerCase().replace(/-/g, " ").replace(/\b[a-z]/g, function(letter) {
+  //     return letter.toUpperCase();
+  //   });
+  // }
+  //
+  // var myLabelCounter = "";
+  //
+  // if (totalEls > 1) {
+  //   myLabelCounter = " " + myCounter;
+  // }
+  //
+  // // if an h1 was found, we can use that as-is
+  // if (myHeading[0] !== undefined) {
+  //   newHeading = myHeading;
+  // // otherwise, turn the label we created into an h1 tag
+  // // and add the required counter
+  // } else {
+  //   myLabel = myLabel + myLabelCounter;
+  //   newHeading = "<h1>" + myLabel + "</h1>";
+  // }
 
-  // get the total number of elements of this type
-  var mySelector = "";
-  var totalEls = "";
-  var myLabel = "";
-  var myCounter = "";
-
-  // if there is no h1 element found BUT there is a title attribute on the section,
-  // use the title attribute as the heading text
-  if (myHeading[0] === undefined && myTitle !== undefined) {
-    mySelector = myEl + "[title='" + myTitle + "']";
-    totalEls = getAutoNumber(mySelector);
-    myCounter = getCounter(hash, myTitle);
-    myLabel = myTitle;
-  // otherwise if there is no h1 element, use the data-type value
-  } else if (myHeading[0] === undefined && myTitle === undefined) {
-    // adjust the capitalization of the data-type value for human-readability
-    mySelector = myEl + "[data-type='" + myType + "']";
-    totalEls = getAutoNumber(mySelector);
-    myCounter = getCounter(hash, myType);
-    myLabel = myType.toLowerCase().replace(/-/g, " ").replace(/\b[a-z]/g, function(letter) {
-      return letter.toUpperCase();
-    });
+    // add the heading to the header element
+    var newHeading = $("<h1/>").prepend(sectionStartParaContent);
+    var newHeader = $("<header/>").prepend(newHeading);
+    $(this).prepend(newHeader);
   }
-
-  var myLabelCounter = "";
-
-  if (totalEls > 1) {
-    myLabelCounter = " " + myCounter;
-  }
-
-  // if an h1 was found, we can use that as-is
-  if (myHeading[0] !== undefined) {
-    newHeading = myHeading;
-  // otherwise, turn the label we created into an h1 tag
-  // and add the required counter
-  } else {
-    myLabel = myLabel + myLabelCounter;
-    newHeading = "<h1>" + myLabel + "</h1>";
-  }
-
-  // add the heading to the header element
-  var newHeader = $("<header/>").prepend(newHeading);
-  $(this).prepend(newHeader);
 });
+
+// remove any old divider (section start) paragraphs now that we scooped up their content for headers
+$("p.sectionstartpara").remove();
 
 // add autonumbering to parts, chapters, appendixes
 $("section[data-type='chapter']").each(function( index ){

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -554,9 +554,7 @@ $("section, div[data-type='part']").each(function( ){
   if (sectionStartPara.length > 0) {
     var sectionStartParaContent = sectionStartPara.text();
     if (sectionStartParaContent != "") {
-      console.log("found " + sectionStartParaContent); // debug
     } else {
-      console.log("founf emprty secitonstst")
       // inserting a blank space, so the h1 element gets created. The ncx.xsl will turn this into an empty ncx element, which will fail epubcheck..
       //  which is what we want so users learn? (for now)
       sectionStartParaContent = " "

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -189,11 +189,6 @@ for (var k in toplevelheads) {
   });
 };
 
-// // remove the old divider paragraphs
-// toplevelheadsarr.forEach(function ( val ) {
-//   $( val ).remove();
-// });
-
 // wrap extracts in blockquote; include versatile paragraphs
 var extractAndVersatileParas = extractparas.concat(versatileblockparas);
 var extractAndVersatileList = extractAndVersatileParas.join(", ");
@@ -548,7 +543,7 @@ function getCounter(myHash, mySelector) {
 var hash = {};
 
 // creating the header block;
-// we want content entered by the user in Section Start para as the header h1 text; using previous setup as a backup
+// we want the header h1 text to come from user-entered content in Section Start para; using previous header configuration as a backup, & for Section-Notes
 $("section, div[data-type='part']").each(function( ){
   var sectionStartPara = $(this).children("p.sectionstartpara").first()
   if (sectionStartPara.length > 0) {
@@ -556,7 +551,7 @@ $("section, div[data-type='part']").each(function( ){
     if (sectionStartParaContent != "") {
     } else {
       // inserting a blank space, so the h1 element gets created. The ncx.xsl will turn this into an empty ncx element, which will fail epubcheck..
-      //  which is what we want so users learn? (for now)
+      //  which is what we want so users learn (for now)
       sectionStartParaContent = " "
     }
     // add the heading to the header element

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -530,9 +530,6 @@ headingslistselector.each(function(){
 
 // SETTING THE HEADER:
 
-// All of the below lines for setting the Header will be used as a fallback for the new primary method; which is capturing the Section Start Para contents
-// $("section, div[data-type='part']").each(function( ){
-
 // functions for counting sections, so we can autonumber if needed
 function getAutoNumber(mySelector) {
   var n = $(mySelector).length;
@@ -551,67 +548,70 @@ function getCounter(myHash, mySelector) {
 var hash = {};
 
 // creating the header block;
-// primarily we want content entered by the user, we may use previous setup as a backup.. commenting for now
-// (that relied on that we h1 tags created previously)
+// we want content entered by the user in Section Start para as the header h1 text; using previous setup as a backup
 $("section, div[data-type='part']").each(function( ){
-  var sectionStartParaContent = $(this).children("p.sectionstartpara").first().text();
-  if (sectionStartParaContent != "") {
-    console.log("found " + sectionStartParaContent); // debug
-    // Now we're not inserting a header if there's no section start para contents?
-    // Cuz if we insert a blank, well, should we insert a blank? if so just uncomment this block below, adn
-    // remove bracket from the end below... well what happens to th eTOC? We should test both ways.
-    // maybe the empty string is fine too
-  // } else {
-  //   sectionStartParaContent = " " // so we have something in there... but this may interfere with
-  // }
-  // old header handling:
-  // var myHeading = $(this).children("h1").first().clone().removeAttr("class").removeAttr("id");
-  // var myTitle = $(this).attr("title");
-  // var myType = $(this).attr("data-type");
-  // var myEl = this.tagName.toLowerCase();
-  //
-  // // get the total number of elements of this type
-  // var mySelector = "";
-  // var totalEls = "";
-  // var myLabel = "";
-  // var myCounter = "";
-  //
-  // // if there is no h1 element found BUT there is a title attribute on the section,
-  // // use the title attribute as the heading text
-  // if (myHeading[0] === undefined && myTitle !== undefined) {
-  //   mySelector = myEl + "[title='" + myTitle + "']";
-  //   totalEls = getAutoNumber(mySelector);
-  //   myCounter = getCounter(hash, myTitle);
-  //   myLabel = myTitle;
-  // // otherwise if there is no h1 element, use the data-type value
-  // } else if (myHeading[0] === undefined && myTitle === undefined) {
-  //   // adjust the capitalization of the data-type value for human-readability
-  //   mySelector = myEl + "[data-type='" + myType + "']";
-  //   totalEls = getAutoNumber(mySelector);
-  //   myCounter = getCounter(hash, myType);
-  //   myLabel = myType.toLowerCase().replace(/-/g, " ").replace(/\b[a-z]/g, function(letter) {
-  //     return letter.toUpperCase();
-  //   });
-  // }
-  //
-  // var myLabelCounter = "";
-  //
-  // if (totalEls > 1) {
-  //   myLabelCounter = " " + myCounter;
-  // }
-  //
-  // // if an h1 was found, we can use that as-is
-  // if (myHeading[0] !== undefined) {
-  //   newHeading = myHeading;
-  // // otherwise, turn the label we created into an h1 tag
-  // // and add the required counter
-  // } else {
-  //   myLabel = myLabel + myLabelCounter;
-  //   newHeading = "<h1>" + myLabel + "</h1>";
-  // }
-
+  var sectionStartPara = $(this).children("p.sectionstartpara").first()
+  if (sectionStartPara.length > 0) {
+    var sectionStartParaContent = sectionStartPara.text();
+    if (sectionStartParaContent != "") {
+      console.log("found " + sectionStartParaContent); // debug
+    } else {
+      console.log("founf emprty secitonstst")
+      // inserting a blank space, so the h1 element gets created. The ncx.xsl will turn this into an empty ncx element, which will fail epubcheck..
+      //  which is what we want so users learn? (for now)
+      sectionStartParaContent = " "
+    }
     // add the heading to the header element
     var newHeading = $("<h1/>").prepend(sectionStartParaContent);
+    var newHeader = $("<header/>").prepend(newHeading);
+    $(this).prepend(newHeader);
+  } else {
+    // old header handling: // (relies on h1 tags that we created previously)
+    var myHeading = $(this).children("h1").first().clone().removeAttr("class").removeAttr("id");
+    var myTitle = $(this).attr("title");
+    var myType = $(this).attr("data-type");
+    var myEl = this.tagName.toLowerCase();
+
+    // get the total number of elements of this type
+    var mySelector = "";
+    var totalEls = "";
+    var myLabel = "";
+    var myCounter = "";
+
+    // if there is no h1 element found BUT there is a title attribute on the section,
+    // use the title attribute as the heading text
+    if (myHeading[0] === undefined && myTitle !== undefined) {
+      mySelector = myEl + "[title='" + myTitle + "']";
+      totalEls = getAutoNumber(mySelector);
+      myCounter = getCounter(hash, myTitle);
+      myLabel = myTitle;
+    // otherwise if there is no h1 element, use the data-type value
+    } else if (myHeading[0] === undefined && myTitle === undefined) {
+      // adjust the capitalization of the data-type value for human-readability
+      mySelector = myEl + "[data-type='" + myType + "']";
+      totalEls = getAutoNumber(mySelector);
+      myCounter = getCounter(hash, myType);
+      myLabel = myType.toLowerCase().replace(/-/g, " ").replace(/\b[a-z]/g, function(letter) {
+        return letter.toUpperCase();
+      });
+    }
+
+    var myLabelCounter = "";
+
+    if (totalEls > 1) {
+      myLabelCounter = " " + myCounter;
+    }
+
+    // if an h1 was found, we can use that as-is
+    if (myHeading[0] !== undefined) {
+      newHeading = myHeading;
+    // otherwise, turn the label we created into an h1 tag
+    // and add the required counter
+    } else {
+      myLabel = myLabel + myLabelCounter;
+      newHeading = "<h1>" + myLabel + "</h1>";
+    }
+    // add the heading to the header element
     var newHeader = $("<header/>").prepend(newHeading);
     $(this).prepend(newHeader);
   }


### PR DESCRIPTION
@lsquill, please review, @ericawarren fyi :)
I looked at doing this a couple of ways in the htmltohtmlbook script:

- capturing the text and putting it in the section element as an attribute (encoding double quotes & ampersands), or
- using the text to populate the existing non-printing "header" element, essentially a meta-element Nellie added to conform to the [HTMLbook spec](https://oreillymedia.github.io/HTMLBook/#header_block).

I went with the latter b/c leveraging the header meant I could leave the existing O'Reilly ncx.xsl intact, and this seemed like a reasonable use of the header element.  

An accompanying PR will be submitted shortly from the bookmaker_addons repo; moving the header removal from epubmaker_preprocessing to epubmaker_postprocessing.