### PR TITLE
changed hyphen to underscore for footnote / endnote generated ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,10 +560,10 @@ When running the full conversion from .docx to HTMLBook, footnotes that are embe
 </div>
 ```
 
-* Footnote references (the marker denoting the location in the text to which the footnote corresponds) must be tagged as a span with an id of "footnote-' \+ the note number. E.g.:
+* Footnote references (the marker denoting the location in the text to which the footnote corresponds) must be tagged as a span with an id of "footnote_' \+ the note number. E.g.:
 
 ```html
-<p class="TextStandardtx">Macmillan Publishers is currently located in the Flatiron Building.<span id="footnote-1">1</span></p>
+<p class="TextStandardtx">Macmillan Publishers is currently located in the Flatiron Building.<span id="footnote_1">1</span></p>
 ```
 
 #### Sample 1

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -65,7 +65,7 @@ var Convert = function (styleFunctionsPath) {
 				}
 				if (isFootnote == true && child.styleId !== "EndnoteReference") {
 					span.addClass("FootnoteRef");
-					var noteId = "footnote-" + data.noteId;
+					var noteId = "footnote_" + data.noteId;
 					span.attr('id', noteId);
 				}
 				span.text(paraText);
@@ -184,7 +184,7 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
   notesjsonarr.forEach(function (note, index, paras) {
     if (note.noteType == "endnote") {
   		  var noteparent = $("<div class='endnotetext'></div>");
-  		  var endnoteid = "endnotetext-" + note.noteId;
+  		  var endnoteid = "endnotetext_" + note.noteId;
   		  noteparent.attr("id", endnoteid);
 				note.body.forEach(function (para, index, paras) {
 					var p = $("<p></p>");
@@ -206,7 +206,7 @@ Convert.prototype.convertDocx = function (stylesJson, docx, docxStyles) {
   $('span.EndnoteReference').each(function () {
   	var parentclass = $(this).parent().attr("class").toLowerCase();
   	var notenumber = $(this).contents();
-  	var newid = "endnoteref-" + notenumber;
+  	var newid = "endnoteref_" + notenumber;
   	var childspan = $("<span class='endnotereference'></span>").attr("id", newid);
   	if (parentclass !== "endnotetext") {
 	    $(this).contents().wrap(childspan);

--- a/lib/htmltohtmlbook.js
+++ b/lib/htmltohtmlbook.js
@@ -474,7 +474,7 @@ var footnotelistselector = $(footnotelist);
 
 footnotelistselector.each(function () {
   var notenumber = $(this).attr('data-noteref');
-  var node = $('span[id=footnote-' + notenumber + ']');
+  var node = $('span[id=footnote_' + notenumber + ']');
   node.empty();
   while ((this.firstChild) && (this.firstChild.children.length > 0)) {
     node.append(this.firstChild);


### PR DESCRIPTION
To help fix / prevent  https://github.com/macmillanpublishers/bookmaker_addons/issues/180
Part of general hyphen handling.